### PR TITLE
[pcc-66-2] Muestra las películas relacionadas con datos reales del backend.

### DIFF
--- a/popCornClub/api/src/main/java/com/imatia/popcornclub/api/core/service/IMovieService.java
+++ b/popCornClub/api/src/main/java/com/imatia/popcornclub/api/core/service/IMovieService.java
@@ -15,4 +15,5 @@ public interface IMovieService {
     public EntityResult movieDelete(Map<String, Object> keyMap)throws OntimizeJEERuntimeException;
     public EntityResult infoMoviesQuery(Map<String, Object> keyMap, List<String > attrList) throws OntimizeJEERuntimeException;
     public EntityResult lastMoviesQuery(Map<String, Object> keyMap, List<String > attrList) throws OntimizeJEERuntimeException;
+    public EntityResult relatedMoviesQuery(Map<String, Object> keyMap, List<String > attrList) throws OntimizeJEERuntimeException;
 }

--- a/popCornClub/frontend/src/main/ngx/src/app/main/movies/movies-view/related-movies/related-movies.component.ts
+++ b/popCornClub/frontend/src/main/ngx/src/app/main/movies/movies-view/related-movies/related-movies.component.ts
@@ -31,8 +31,12 @@ export class RelatedMoviesComponent implements OnInit {
         "columns": ["id_movie", "movie_name", "duration", "critic", "description", "poster", "premiere", "trailer", "movie_year", "media_rating"]
       };
       http.post(this.relatedMoviesEndPoint, JSON.stringify(requestBody), this.httpOptions).subscribe(response => {
-        // FIXME: Añadir a this.relatedMovies las peliculas retornadas por el backend
-        this.relatedMovies = response["data"]
+        this.relatedMovies = [];
+        response["data"].forEach(movieToFilter => {
+          if (movieToFilter["id_movie"] != params["id"]) {
+            this.relatedMovies.push(movieToFilter);
+          }
+        });
       });
     });
   }

--- a/popCornClub/frontend/src/main/ngx/src/app/main/movies/movies-view/related-movies/related-movies.component.ts
+++ b/popCornClub/frontend/src/main/ngx/src/app/main/movies/movies-view/related-movies/related-movies.component.ts
@@ -9,24 +9,9 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 })
 export class RelatedMoviesComponent implements OnInit {
 
-  relatedMovies = [
-    {
-      "id": 5,
-      "poster": "https://m.media-amazon.com/images/M/MV5BZjVkYzY4OWEtMjc2OC00YTQ0LWIwMmUtYTRlODc3ODBmZjcxXkEyXkFqcGdeQXVyMjkyODc0ODk@._V1_UY268_CR5,0,182,268_AL_.jpg",
-      "movie_name": "Indiana Jones y el santuario de la orden negra",
-      "description": "1938. A group of American archaeologists are taken prisoners in the Castle of Wewelsburg. Indiana Jones with Sallah and Husani will travel to the Nazi Vatican, to discover the last and the darkest plan of the Third Reich.",
-      "media_rating": 7,
-    },
-    {
-      "id": 1,
-      "poster": "https://m.media-amazon.com/images/M/MV5BZjVkYzY4OWEtMjc2OC00YTQ0LWIwMmUtYTRlODc3ODBmZjcxXkEyXkFqcGdeQXVyMjkyODc0ODk@._V1_UY268_CR5,0,182,268_AL_.jpg",
-      "movie_name": "Indiana Jones y el santuario de la orden negra",
-      "description": "1938. A group of American archaeologists are taken prisoners in the Castle of Wewelsburg. Indiana Jones with Sallah and Husani will travel to the Nazi Vatican, to discover the last and the darkest plan of the Third Reich.",
-      "media_rating": 7,
-    }
-  ];
+  relatedMovies = [];
 
-  relatedMoviesEndPoint = "http://localhost:33333/movies/movie";
+  relatedMoviesEndPoint = "http://localhost:33333/movies/relatedMovies/search";
   httpOptions = {
     headers: new HttpHeaders({
       'Authorization': 'Basic ZGVtbzpkZW1vdXNlcg==',
@@ -38,16 +23,19 @@ export class RelatedMoviesComponent implements OnInit {
     private router: Router,
     private actRoute: ActivatedRoute,
     private http: HttpClient) {
-    let requestBody = {
-      "filter": {
-       
-      },
-      "columns": ["id_movie", "movie_name", "duration", "critic", "description", "poster", "premiere", "trailer", "movie_year", "media_rating"]
-    };
-    http.post(this.relatedMoviesEndPoint, JSON.stringify(requestBody), this.httpOptions).subscribe(response => {
-      // FIXME: Añadir a this.relatedMovies las peliculas retornadas por el backend
+    actRoute.params.subscribe((params) => {
+      let requestBody = {
+        "filter": {
+          "id_movie": Number(params["id"])
+        },
+        "columns": ["id_movie", "movie_name", "duration", "critic", "description", "poster", "premiere", "trailer", "movie_year", "media_rating"]
+      };
+      http.post(this.relatedMoviesEndPoint, JSON.stringify(requestBody), this.httpOptions).subscribe(response => {
+        // FIXME: Añadir a this.relatedMovies las peliculas retornadas por el backend
+        this.relatedMovies = response["data"]
+      });
     });
-   }
+  }
 
   ngOnInit() {
   }

--- a/popCornClub/model/src/main/java/com/imatia/popcornclub/model/core/service/MovieService.java
+++ b/popCornClub/model/src/main/java/com/imatia/popcornclub/model/core/service/MovieService.java
@@ -51,5 +51,10 @@ public class MovieService implements IMovieService{
         return this.daoHelper.query(this.movieDao, keyMap, attrList, "lastMovies");
     }
 
+    @Override
+    public EntityResult relatedMoviesQuery(Map<String, Object> keyMap, List<String> attrList) throws OntimizeJEERuntimeException {
+        return this.daoHelper.query(this.movieDao, keyMap, attrList, "relatedMovies");
+    }
+
 
 }

--- a/popCornClub/model/src/main/resources/dao/MovieDao.xml
+++ b/popCornClub/model/src/main/resources/dao/MovieDao.xml
@@ -13,7 +13,7 @@
     </UpdateKeys>
     <GeneratedKey>id_movie</GeneratedKey>
     
-    <Queries> 
+    <Queries>
         <Query id="infoMovies">
         <AmbiguousColumns>
             <AmbiguousColumn name="id_movie" prefix="movie" />
@@ -45,6 +45,19 @@
 			        #WHERE#
 					ORDER BY premiere desc
 					LIMIT 6
+                ]]>
+            </Sentence>
+        </Query>
+
+        <Query id="relatedMovies">
+            <Sentence>
+                <![CDATA[
+                    select #COLUMNS#
+                     from movie where id_movie in (select id_movie from (
+                     select id_movie, count(*) as related from genre_has_movie ghm where id_genre in (select id_genre from genre_has_movie ghm2
+                     #WHERE# and media_rating > 5) group by id_movie
+                     ) as relation where relation.related > 1
+                    ) LIMIT 3
                 ]]>
             </Sentence>
         </Query>

--- a/popCornClub/ws/src/main/java/com/imatia/popcornclub/ws/core/rest/MovieRestController.java
+++ b/popCornClub/ws/src/main/java/com/imatia/popcornclub/ws/core/rest/MovieRestController.java
@@ -56,4 +56,18 @@ public class MovieRestController extends ORestController<IMovieService>{
    			return res;
    		}
    	}
+
+	@RequestMapping(value = "/relatedMovies", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+	public EntityResult getRelatedMovie(@RequestBody Map<String, Object> req) {
+		try {
+			List<String> columns = (List<String>) req.get("columns");
+			Map<String, Object> key = new HashMap<String, Object>();
+			return movieService.relatedMoviesQuery(key, columns);
+		} catch (Exception e) {
+			e.printStackTrace();
+			EntityResult res = new EntityResult();
+			res.setCode(EntityResult.OPERATION_WRONG);
+			return res;
+		}
+	}
 }


### PR DESCRIPTION
Sustitución de mockup de películas relacionadas con datos reales de la base de datos.

La consulta de backend busca película con dos o más géneros en común y una media por encima de 5.

Antes de añadir las películas al componente de visualización se ignora la película que ya se está visualizando.